### PR TITLE
User can fetch single food

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -16,6 +16,30 @@ router.get('/', (request, response) => {
     response.setHeader('Content-Type', 'application/json');
     response.status(500).send({ error })
   })
+});
+
+router.get('/:id', (request, response) => {
+  return Food.findOne({
+    attributes: { 
+      exclude: ['createdAt', 'updatedAt'] 
+    }, 
+    where: {
+      id: request.params.id
+    }
+  })
+  .then(food => {
+    if (food) {
+    response.setHeader('Content-Type', 'application/json');
+    response.status(200).send(JSON.stringify(food));
+    } else {
+      response.setHeader('Content-Type', 'application/json');
+      response.status(404).send(JSON.stringify({error: "Food not found."}));
+    }
+  })
+  .catch(error => {
+    response.setHeader('Content-Type', 'application/json');
+    response.status(500).send({ error })
+  })
 })
 
 module.exports = router;

--- a/tests/api/v1/foods_api_endpoint.spec.js
+++ b/tests/api/v1/foods_api_endpoint.spec.js
@@ -38,16 +38,53 @@ describe('foods api endpoint', () => {
         updatedAt: new Date()
       }
     ])
-
+    .then(food => {
     return request(app)
     .get('/api/v1/foods')
     .then(response => {
       expect(response.statusCode).toBe(200)
-
       expect(response.body.length).toBe(4)
       expect(Object.keys(response.body[0])).toContain('id')
       expect(Object.keys(response.body[0])).toContain('name')
       expect(Object.keys(response.body[0])).toContain('calories')
+    })
+    })
+  });
+  test('user can return a single food', () => {
+    return Food.bulkCreate([
+      {
+        id: 6,
+        name: 'Mango',
+        calories: 120,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        id: 8,
+        name: 'Orange',
+        calories: 80,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ])
+    .then(food =>{
+      return request(app)
+      .get('/api/v1/foods/6')
+      .then(response => {
+        expect(response.statusCode).toBe(200)
+        expect(Object.values(response.body)).toContain(6)
+        expect(Object.values(response.body)).toContain('Mango')
+        expect(Object.values(response.body)).toContain(120)
+        expect(Object.keys(response.body)).not.toContain('createdAt')
+      })
+    });
+  });
+  test("user gets 404 when they fetch single food with invalid id", () => {
+    return request(app)
+    .get('/api/v1/foods/100')
+    .then(response => {
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe('Food not found.')
     })
   })
 })


### PR DESCRIPTION
Added show endpoint at api/v1/foods/:id for user requests to fetch a single food by id.
added tests for the request and sad path test for when fetch fails to locate item.