### PR TITLE
User Can Delete Existing Food

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -22,9 +22,9 @@ router.get('/', (request, response) => {
 
 router.get('/:id', (request, response) => {
   return Food.findOne({
-    attributes: { 
-      exclude: ['createdAt', 'updatedAt'] 
-    }, 
+    attributes: {
+      exclude: ['createdAt', 'updatedAt']
+    },
     where: {
       id: request.params.id
     }
@@ -63,6 +63,30 @@ router.patch('/:id', (request, response) => {
           name: updatedFood.name,
           calories: updatedFood.calories
         }));
+      })
+      .catch(error => {
+        response.setHeader('Content-Type', 'application/json');
+        response.status(500).send({ error });
+      })
+    } else {
+      response.setHeader('Content-Type', 'application/json');
+      response.status(404).send(JSON.stringify({ error: 'Food not found.' }));
+    }
+  })
+})
+
+router.delete('/:id', (request, response) => {
+  return Food.findOne({
+    where: {
+      id: request.params.id,
+    }
+  })
+  .then(food => {
+    if (food) {
+      return food.destroy()
+      .then(destroyedFood => {
+        response.setHeader('Content-Type', 'application/json');
+        response.status(204).send(JSON.stringify(destroyedFood))
       })
       .catch(error => {
         response.setHeader('Content-Type', 'application/json');

--- a/tests/api/v1/foods_api_endpoint.spec.js
+++ b/tests/api/v1/foods_api_endpoint.spec.js
@@ -81,7 +81,7 @@ describe('foods api endpoint', () => {
         expect(Object.values(response.body)).toContain(6)
         expect(Object.values(response.body)).toContain('Mango')
         expect(Object.values(response.body)).toContain(120)
-        
+
         expect(Object.keys(response.body)).not.toContain('createdAt')
         expect(Object.keys(response.body)).not.toContain('updatedAt')
       })
@@ -130,6 +130,31 @@ describe('foods api endpoint', () => {
       name: 'Gooseberry',
       calories: 10
     })
+    .then(response => {
+      expect(response.status).toBe(404)
+      expect(response.body.error).toBe('Food not found.')
+    })
+  })
+
+  test('user can delete existing food', () => {
+    return Food.create({
+      name: 'Raspberry',
+      calories: 10,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+    .then(food => {
+      return request(app)
+      .delete(`/api/v1/foods/${food.id}`)
+    })
+    .then(response => {
+      expect(response.status).toBe(204)
+    })
+  })
+
+  test('user recieves a 404 error when no food is found to delete', () => {
+    return request(app)
+    .delete('/api/v1/foods/9999')
     .then(response => {
       expect(response.status).toBe(404)
       expect(response.body.error).toBe('Food not found.')

--- a/tests/api/v1/foods_api_endpoint.spec.js
+++ b/tests/api/v1/foods_api_endpoint.spec.js
@@ -123,7 +123,7 @@ describe('foods api endpoint', () => {
     })
   })
 
-  test('user recieves a 404 error when no food is found to update', () => {
+  test('user receives a 404 error when no food is found to update', () => {
     return request(app)
     .patch('/api/v1/foods/9999')
     .send({


### PR DESCRIPTION
This PR adds an endpoint for a user to delete an existing food in the database.

- Adds spec for user deleting an existing food
- Adds endpoint to foodsRouter for user deleting an existing food