### PR TITLE
User Can Fetch All Meals

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
 var foodsRouter = require('./routes/api/v1/foods');
+var mealsRouter = require('./routes/api/v1/meals');
 
 var app = express();
 
@@ -23,6 +24,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1/foods', foodsRouter);
+app.use('/api/v1/meals', mealsRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/migrations/20190821214100-create-meal.js
+++ b/migrations/20190821214100-create-meal.js
@@ -9,6 +9,7 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       name: {
+        allowNull: false,
         type: Sequelize.STRING
       },
       createdAt: {

--- a/models/food.js
+++ b/models/food.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
     calories: DataTypes.INTEGER
   }, {
     hooks: {
-      beforeCreate: (food) => {
+      beforeSave: (food) => {
         food.name = toTitleCase(food.name);
       }
     }

--- a/models/meal.js
+++ b/models/meal.js
@@ -6,16 +6,16 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING
   }, {
     hooks: {
-      beforeCreate: (food) => {
+      beforeSave: (food) => {
         food.name = toTitleCase(food.name);
       }
     }
   });
   Meal.associate = function(models) {
     Meal.belongsToMany(models.Food, {
-      through: 'MealFoods', 
+      through: 'MealFoods',
       foreignKey: 'MealId',
-      otherKey: 'FoodId', 
+      otherKey: 'FoodId',
       as: 'foods',
     })
   };

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -5,14 +5,10 @@ var Food = require('../../../models').Food;
 var router = express.Router();
 
 router.get('/', (request, response) => {
-  return Food.findAll({
-    attributes: {
-      exclude: ['createdAt', 'updatedAt']
-    }
-  })
+  return Food.findAll()
   .then(foods => {
     response.setHeader('Content-Type', 'application/json');
-    response.status(200).send(JSON.stringify(foods));
+    response.status(200).send(JSON.stringify(foods, ['id', 'name', 'calories']));
   })
   .catch(error => {
     response.setHeader('Content-Type', 'application/json');
@@ -22,9 +18,6 @@ router.get('/', (request, response) => {
 
 router.get('/:id', (request, response) => {
   return Food.findOne({
-    attributes: {
-      exclude: ['createdAt', 'updatedAt']
-    },
     where: {
       id: request.params.id
     }
@@ -32,7 +25,7 @@ router.get('/:id', (request, response) => {
   .then(food => {
     if (food) {
     response.setHeader('Content-Type', 'application/json');
-    response.status(200).send(JSON.stringify(food));
+    response.status(200).send(JSON.stringify(food, ['id', 'name', 'calories']));
     } else {
       response.setHeader('Content-Type', 'application/json');
       response.status(404).send(JSON.stringify({error: 'Food not found.'}));

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -82,7 +82,6 @@ router.post('/', (request, response) => {
     response.status(201).send(JSON.stringify(food, ['id', 'name', 'calories'] ));
   })
   .catch(error => {
-    console.log(error)
     response.setHeader('Content-Type', 'application/json')
     response.status(400).send(JSON.stringify({ error: 'Food not created.' }));
   })

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -1,0 +1,22 @@
+var express = require('express');
+
+var Meal = require('../../../models').Meal;
+var Food = require('../../../models').Food;
+
+var router = express.Router();
+
+router.get('/', (request, response) => {
+  return Meal.findAll({
+    include: 'foods'
+  })
+  .then(meals => {
+    response.setHeader('Content-Type', 'application/json');
+    response.status(200).send(JSON.stringify(meals, ['id', 'name', 'foods', 'id', 'name', 'calories']));
+  })
+  .catch(error => {
+    response.setHeader('Content-Type', 'application/json');
+    response.status(500).send({ error });
+  })
+})
+
+module.exports = router;

--- a/tests/api/v1/foods_api_endpoint.spec.js
+++ b/tests/api/v1/foods_api_endpoint.spec.js
@@ -7,8 +7,8 @@ var app = require('../../../app');
 var cleanup = require('../../../tests/helpers/test_clear_database');
 
 describe('foods api endpoint', () => {
-  beforeEach(() => {
-    cleanup();
+  beforeEach(async function() {
+    await cleanup();
   })
 
   test('user can fetch all foods', () => {

--- a/tests/api/v1/foods_api_endpoint.spec.js
+++ b/tests/api/v1/foods_api_endpoint.spec.js
@@ -112,6 +112,7 @@ describe('foods api endpoint', () => {
         calories: 10
       })
       .then(response => {
+        console.log(response.body)
         expect(response.status).toBe(202);
 
         expect(Object.keys(response.body)).toContain('id');

--- a/tests/api/v1/meals_api_endpoint.spec.js
+++ b/tests/api/v1/meals_api_endpoint.spec.js
@@ -1,0 +1,80 @@
+var shell = require('shelljs');
+var request = require('supertest');
+
+var Meal = require('../../../models').Meal;
+var Food = require('../../../models').Food;
+
+var app = require('../../../app');
+var cleanup = require('../../../tests/helpers/test_clear_database');
+
+describe('meals api endpoint', () => {
+  beforeEach(async function() {
+    await cleanup();
+  })
+
+  test('user can fetch all meals', () => {
+    return Meal.create({
+      name: 'Brinner',
+      foods: [
+        {
+          name: 'Waffles',
+          calories: 800
+        },
+        {
+          name: 'Hot Sauce',
+          calories: 30
+        },
+        {
+          name: 'Mimosa',
+          calories: 300
+        }
+      ]
+    }, {
+      include: 'foods'
+    })
+    .then(meal => {
+      return Meal.create({
+        name: 'Linner',
+        foods: [
+          {
+            name: 'Quesadilla',
+            calories: 1200
+          },
+          {
+            name: 'Salsa',
+            calories: 40
+          },
+          {
+            name: 'Sour Cream',
+            calories: 400
+          }
+        ]
+      }, {
+        include: 'foods'
+      })
+    })
+    .then(meal => {
+      return request(app)
+      .get('/api/v1/meals')
+      .then(response => {
+        expect(response.statusCode).toBe(200);
+
+        expect(response.body.length).toBe(2);
+        expect(Object.keys(response.body[0])).toContain('id');
+        expect(Object.keys(response.body[0])).toContain('name');
+        expect(Object.keys(response.body[0])).toContain('foods');
+
+        expect(Object.keys(response.body[0])).not.toContain('createdAt');
+        expect(Object.keys(response.body[0])).not.toContain('updatedAt');
+
+        expect(response.body[0].foods.length).toBe(3);
+        expect(Object.keys(response.body[0].foods[0])).toContain('id');
+        expect(Object.keys(response.body[0].foods[0])).toContain('name');
+        expect(Object.keys(response.body[0].foods[0])).toContain('calories');
+
+        expect(Object.keys(response.body[0].foods[0])).not.toContain('createdAt');
+        expect(Object.keys(response.body[0].foods[0])).not.toContain('updatedAt');
+      })
+    })
+  })
+})

--- a/tests/helpers/test_clear_database.js
+++ b/tests/helpers/test_clear_database.js
@@ -1,7 +1,9 @@
-var Food = require('../../models').Food;
 var Meal = require('../../models').Meal;
+var Food = require('../../models').Food;
+var MealFood = require('../../models').MealFood;
 
 module.exports = async function cleanup() {
   await Food.destroy({ where: {} })
   await Meal.destroy({ where: {} })
+  await MealFood.destroy({ where: {} })
 }

--- a/tests/models/food.spec.js
+++ b/tests/models/food.spec.js
@@ -5,8 +5,8 @@ var Food = require('../../models').Food;
 var Meal = require('../../models').Meal;
 
 describe('food model', () => {
-  beforeEach(() => {
-    cleanup();
+  beforeEach(async function() {
+    await cleanup();
   })
 
   test('it has attributes', () => {

--- a/tests/models/meal.spec.js
+++ b/tests/models/meal.spec.js
@@ -5,8 +5,8 @@ var Meal = require('../../models').Meal;
 var Food = require('../../models').Food;
 
 describe('Meal model', () => {
-  beforeEach(() => {
-    cleanup();
+  beforeEach(async function() {
+    await cleanup();
   })
 
   test('it has attributes', () => {


### PR DESCRIPTION
This PR adds an endpoint for a user to fetch all meals, along with their corresponding foods.

- Changes beforeCreate hook in Food/Meal models to beforeSave hook
- Changes beforeEach test blocks to asynchronous functions
- Adds spec for user fetching all meals and foods
- Adds mealsRouter with index route